### PR TITLE
Changes the format of the signature to allow for later extensions.

### DIFF
--- a/example.html
+++ b/example.html
@@ -1,10 +1,25 @@
 <!doctype html>
-<!--!
-%%%SIGNED_PAGES_PGP_SIGNATURE%%%
--->
 <html lang="en">
   <head>
     <meta charset="utf-8">
+    <meta name="signature" content="
+      type=pgp,
+      version=1.0.0,
+      allowedMethods=filterResponseData,
+      signature=
+        %%%SIGNED_PAGES_PGP_SIGNATURE%%%
+    ">
+    <meta name="signature" content="
+      type=pgpMinimized,
+      version=1.0.0,
+      allowedMethods=outsideHTML,
+      signature=
+        %%%SIGNED_PAGES_PGP_SIGNATURE_MIN%%%
+    ">
+    <meta name="trustedPublicKey" content="
+      %%%SIGNED_PAGES_PUBLICKEY%%%
+    ">
+    <meta name="trustedDNS" content="true">
     <title>A signed page example!</title>
   </head>
   <body>

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": 2,
   "name": "Signed Pages",
   "description": "Verifies PGP signed pages for extra security against malicious or breached servers.",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "homepage_url": "https://github.com/tasn/webext-signed-pages",
   "icons": {
       "48": "images/icon.png",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "signed-pages",
   "description": "Verifies PGP signed pages for extra security against malicious or breanched servers.",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "main": "index.js",
   "scripts": {
-    "build": "webpack -w --display-error-details --progress --colors",
+    "build": "npm-install-version minimize@2.1.0 && webpack -w --display-error-details --progress --colors",
     "package": "webpack --colors && web-ext build -s extension",
     "start": "web-ext run -s extension/"
   },
@@ -15,13 +15,13 @@
     "babel-loader": "^7.1.2",
     "babel-preset-react": "^6.24.1",
     "babel-runtime": "^6.26.0",
+    "npm-install-version": "^6.0.2",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "web-ext": "^2.2.2",
     "webpack": "^3.10.0"
   },
   "dependencies": {
-    "minimize": "^2.1.0",
     "openpgp": "^2.6.1",
     "webextension-polyfill": "^0.2.1"
   },

--- a/page-signer.js
+++ b/page-signer.js
@@ -1,19 +1,20 @@
 #!/usr/bin/env node
-/* eslint node: true */
+/* eslint-env node */
+/* eslint-disable no-console */
 
 const fs = require('fs');
 const child_process = require('child_process');
-const Minimize = require('minimize');
+const Minimize = require('minimize@2.1.0');
 
 function errorAbort(text) {
   console.error(text);
   process.exit(1);
 }
 
-function getSignature(content, callback) {
+function getSignature(content, keyid, callback) {
   const tmpfile = `/tmp/${process.pid}`;
   fs.writeFileSync(tmpfile, content, 'utf-8');
-  const gpg = child_process.spawnSync('gpg', ['--armor', '--output', '-', '--detach-sign', tmpfile], {
+  const gpg = child_process.spawnSync('gpg', ['--armor', '--output', '-', '--local-user', keyid, '--detach-sign', tmpfile], {
     stdio: [
       0,
       'pipe',
@@ -21,17 +22,33 @@ function getSignature(content, callback) {
   });
 
   fs.unlink(tmpfile, () => {});
+  const signature = gpg.stdout.toString();
+  if (callback) 
+    callback(signature);
+  return signature;
+}
 
-  callback(gpg.stdout.toString());
+function getPublicKey( keyid, callback) {
+  const gpg = child_process.spawnSync('gpg', ['--armor', '--output', '-', '--export', keyid], {
+    stdio: [
+      0,
+      'pipe',
+    ]
+  });
+  const key = gpg.stdout.toString();
+  if (callback)
+    callback(key);
+  return key;
 }
 
 let args = process.argv.slice(2);
 
+const keyid = args.shift();
 const filename = args.shift();
 const outfile = args.shift();
 
-if (!filename) {
-  errorAbort(`Usage: ${process.argv[1]} <infile> [outfile]`);
+if (!filename || !keyid) {
+  errorAbort(`Usage: ${process.argv[1]} <keyid> <infile> [outfile]`);
 }
 
 fs.readFile(filename, 'utf8', (err, data) => {
@@ -39,21 +56,35 @@ fs.readFile(filename, 'utf8', (err, data) => {
     errorAbort(err);
   }
 
+  const key = getPublicKey(keyid);
+
+  // replace public keys
+  var out  = data.replace('%%%SIGNED_PAGES_PUBLICKEY%%%',  key);
+
+  // Strip placeholders (and whitespace around them)
+  const signed_content = out.replace(/\s*%%%SIGNED_PAGES_PGP_SIGNATURE\w*%%%\s*/g, '');
+
+  console.log(signed_content);
+
+  // Signature of entire document (like pulled from filterResponseData)
+  var signature = getSignature(signed_content, keyid);
+  out  = out.replace('%%%SIGNED_PAGES_PGP_SIGNATURE%%%', signature);
+
+  // Signature using minimize
   // Minimize and strip the doctype
-  const content = new Minimize({ spare:true, conditionals: true, empty: true, quotes: true }).parse(data)
+  const min_content = new Minimize({ spare:true, conditionals: true, empty: true, quotes: true }).parse(signed_content)
     .replace(/^\s*<!doctype[^>]*>/i, '');
 
-  getSignature(content, (signature) => {
-    const out = data.replace('%%%SIGNED_PAGES_PGP_SIGNATURE%%%', signature);
+  signature = getSignature(min_content, keyid);
+  out = out.replace('%%%SIGNED_PAGES_PGP_SIGNATURE_MIN%%%', signature);
 
-    if (outfile) {
-      fs.writeFile(outfile, out, 'utf8', (writeErr) => {
-        if (writeErr) {
-          errorAbort(writeErr);
-        }
-      });
-    } else {
-      process.stdout.write(out);
-    }
-  });
+  if (outfile) {
+    fs.writeFile(outfile, out, 'utf8', (writeErr) => {
+      if (writeErr) {
+        errorAbort(writeErr);
+      }
+    });
+  } else {
+    process.stdout.write(out);
+  }
 });

--- a/src/background.js
+++ b/src/background.js
@@ -5,8 +5,6 @@ import { matchPatternToRegExp } from 'match-pattern';
 
 import * as openpgp from 'openpgp';
 
-import Minimize from 'minimize';
-
 import defaultItems from 'default-items';
 
 function regex(pattern, input) {
@@ -76,27 +74,154 @@ function getPubkey(pubkeyPatterns, url) {
 // Cache the result status in case we are not doing web requests.
 let statusCache = {};
 
-function processPage(rawContent, signature, url, tabId) {
+// Versioned minimize
+function minimize_1_0(rawContent) {
+  const Minimize = require('minimize@2.1.0');
   const content = new Minimize({ spare:true, conditionals: true, empty: true, quotes: true }).parse(rawContent)
-    .replace(/^\s*<!doctype[^>]*>/i, '');
+  .replace(/^\s*<!doctype[^>]*>/i, '');
+  return content;
+}
 
-  const shouldCheck = getPubkey(patterns, url);
+// Version match. 
+// returns true if major and minor are equal and patch less than or equal to taget
+function matchVersions(version, target) {
+  let v = version.split(".").map(i => parseInt(i,10));
+  let t = target.split(".").map(i => parseInt(i,10));
+  if (v.length != 3) 
+    return false;
+  return (v[0] == t[0]) && (v[1] == t[1]) && (v[2] <= t[2]);
+}
 
-  if (shouldCheck) {
-    try {
-      const pubkey = patterns[shouldCheck];
+function defaultOptions() {
+  return {
+    signatures: [],
+    trustedPublicKeys: [],
+    trustedDNS: false,
+  };
+}
 
-      const options = {
-        message: openpgp.message.fromBinary(openpgp.util.str2Uint8Array(content)),
-        signature: openpgp.signature.readArmored(signature),
-        publicKeys: openpgp.key.readArmored(pubkey).keys,
-      };
+function defaultSignature() {
+  return {
+    allowedmethods:['filteredrequestdata', 'outsidehtml']
+  }
+}
 
-      openpgp.verify(options).then((verified) => {
-        const signatureData = (verified.signatures[0].valid) ? goodSignature : badSignature;
-        updateBrowserAction(signatureData, tabId);
-        statusCache[url] = signatureData;
-      });
+function parseOptions(content) {
+  let options = defaultOptions();
+  const head = content.split(/<\/head\s*>/i)[0];
+
+  // Parse signature metadata
+  const signatureRegex = RegExp('<meta\\s+name="signature"\\s+content="([^"]*)"\\s*>', 'gi');
+  const nameRegex = RegExp('\\s*([\\w-]+)=([^,"]*),?', 'gi');
+  let sigMatch;
+  while( (sigMatch = signatureRegex.exec(head)) !== null ) {
+    let signature = defaultSignature();
+    let nameMatch;
+    while ( (nameMatch = nameRegex.exec(sigMatch[1])) !== null ) {
+      const name = nameMatch[1].toLowerCase();
+      if (name == 'signature') {
+        // preserve whitespace to ensure all of it is stripped out
+        signature[name] = nameMatch[2];
+      } else if (name == 'allowedmethods') {
+        // split on spaces
+        signature[name] = nameMatch[2].split(" ").map(s => s.trim().toLowerCase());
+      } else {
+        signature[name] = nameMatch[2].trim().toLowerCase();
+       }
+    }
+    if (signature.type && signature.version && signature.signature)
+      options.signatures.push(signature);
+  }
+
+  return options;
+}
+
+// Strip all signatures from content for signature verification
+function stripSignatures(content, options) {
+  let newContent = content;
+  for (let signature of options.signatures)  {
+    newContent = newContent.replace(signature.signature, "");
+    signature.signature = signature.signature.trim();
+  }
+  return newContent;
+}
+
+function validateSignature(content, signature, pageOptions, pubkey) {
+  const options = {
+    message: openpgp.message.fromBinary(openpgp.util.str2Uint8Array(content)),
+    signature: openpgp.signature.readArmored(signature),
+    publicKeys: openpgp.key.readArmored(pubkey).keys,
+  };
+
+  return openpgp.verify(options).then((verified) => {
+    return verified.signatures[0].valid;
+  });
+}
+
+function validateSignatures(content, options, pubKey, method) {
+  let last = Promise.resolve(false);
+  for (let signature of options.signatures) {
+    let promise = null;
+    if (signature.allowedmethods.includes(method.toLowerCase())) {
+      if (signature.type == 'pgp') {
+        promise = validateSignature(content, signature.signature, options, pubKey);
+      } else if (signature.type == 'pgpMinimized') {
+        if (matchVersions(signature.version, '1.0.0')) {
+          const signedContent = minimize_1_0(content);
+          promise =  validateSignature(signedContent, signature.signature, options, pubKey);
+        }
+      }
+    }
+    // Chain promises returning when the first one is true
+    if (promise) {
+      last = last.then(verified => {
+        if (verified)
+          return verified;
+        else
+          return promise;
+      })
+    }
+  }
+  return last;
+}
+
+function processPage(rawContent, legacySignature, url, tabId, method) {
+  const pattern = getPubkey(patterns, url);
+  if (pattern) {
+    // only test if the user defined a pattern
+    try {  
+      const pubkey = patterns[pattern].trim();
+      let options, content;
+      if (legacySignature) {
+        // Legacy signature
+        options = defaultOptions();
+        options.signatures = [{
+          type: 'pgp_minimized',
+          version: '1.0.0',
+          signature: legacySignature,
+          allowedmethods: ['filterrequestmetadata', 'outsidehtml']
+        }];
+        // ?? Do we need to strip signature? Old code relied on minimizer
+        content = rawContent;
+      } else {
+        options = parseOptions(rawContent);
+        content = stripSignatures(rawContent, options);
+      }
+      if (options !== null) {
+        validateSignatures(content, options, pubkey, method)
+        .then((verified) => {
+          const signatureData = (verified) ? goodSignature : badSignature;
+          updateBrowserAction(signatureData, tabId);
+          statusCache[url] = signatureData;
+        })
+        .catch(() => {
+          updateBrowserAction(badSignature, tabId);
+          statusCache[url] = badSignature;
+        });
+      } else {
+        updateBrowserAction(badSignature, tabId);
+        statusCache[url] = badSignature;
+      }
     } catch (e) {
       updateBrowserAction(badSignature, tabId);
       statusCache[url] = badSignature;
@@ -106,9 +231,10 @@ function processPage(rawContent, signature, url, tabId) {
   }
 }
 
+// extract legacy signature
 function extractSignature(str) {
-  const signatureMatch = /-----BEGIN PGP SIGNATURE-----[^-]*-----END PGP SIGNATURE-----/g.exec(str);
-  return signatureMatch ? signatureMatch[0] : undefined;
+  const signatureMatch = /<!--!\s*(-----BEGIN PGP SIGNATURE-----[^-]*-----END PGP SIGNATURE-----)/g.exec(str);
+  return signatureMatch ? signatureMatch[1] : undefined;
 }
 
 if (hasFilteredResponse()) {
@@ -122,7 +248,7 @@ if (hasFilteredResponse()) {
 
       const signature = extractSignature(str);
 
-      processPage(str, signature, details.url, details.tabId);
+      processPage(str, signature, details.url, details.tabId, "filterResponseData");
 
       filter.write(event.data);
       filter.disconnect();
@@ -149,7 +275,7 @@ if (hasFilteredResponse()) {
 } else {
   browser.runtime.onMessage.addListener(
     (request, sender) => {
-      processPage(request.content, extractSignature(request.signature), sender.url, sender.tab.id)
+      processPage(request.content, extractSignature(request.signature), sender.url, sender.tab.id, "outsideHTML")
     }
   );
 }


### PR DESCRIPTION
- Should be backwards compatible
- Uped version to 0.5.0
- Moves from comment to a meta tag inside head
- Allows multiple signatures
- Allows for a non-minimized signature for firefox users
- Adds an allowedMethods field to signatures to limit when the
  signature  can be used.
- Adds a version field to signatures to allow updating minimizer in the
  the future
- uses npm-install-version to allow multiple versions of the minimizer to
  co-exist in the same codebase to allow updates
- Updated README

Solves #15 and #6.  Lays the foundation for solving #1, #2, #13, and #16
 
Discussion and comments are welcome